### PR TITLE
Fixing issue seen in IE11 where, on initialization, an error gets thrown

### DIFF
--- a/assets/scripts/src/lib/utils.js
+++ b/assets/scripts/src/lib/utils.js
@@ -254,6 +254,7 @@ export const wrap = function(element, wrapper) {
   } else {
     element.parentNode.appendChild(wrapper);
   }
+  element.parentNode.removeChild(element); // IE11 can sometimes throw a 'NoModificationAllowedError' if calling appendChild with an element that already has a parent. This makes sure the error doesn't happen. (https://github.com/webcomponents/webcomponentsjs/issues/856)
   return wrapper.appendChild(element);
 };
 


### PR DESCRIPTION
I was seeing an issue in IE11 (only when dev tools was open) when choices was initializing.

Say I'm loading choices on this `<select>` element:

```html
<div class="select-container">
    <select></select>
</div>
```

Choices' `_createInput` executes and calls on `wrap` to alter the DOM and insert a wrapper element between `<div class="select-container">` and `<select>` (https://github.com/vkolmakov1/Choices/blob/master/assets/scripts/src/choices.js#L2780).

`wrap` is using the Web API `appendChild` (https://developer.mozilla.org/en-US/docs/Web/API/Node/appendChild) function to move the `<select>` element. The mdn link states the function should be able to handle the `<select>` already having a parent. However, IE11 (with dev tools open) was throwing a `"NoModificationAllowedError"` error in this circumstance. Searching around I was able to find this reported issue describing what I was seeing: https://github.com/webcomponents/webcomponentsjs/issues/856. 

The workaround - to remove the `<select>` element's parent before calling `appendChild` - stops the `"NoModificationAllowedError"` being thrown.